### PR TITLE
Fix compilation with giflib-5 and later

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -289,7 +289,7 @@ dnl MinGW check for libungif
 AC_CHECK_LIB(ungif, DGifOpen, GIFLIB="-lungif")
 dnl Solaris needs -lX11 on the linker line for ungif to work
 AC_CHECK_LIB(gif, GifErrorString, GIFLIB="-lgif",, "-lX11")
-AC_CHECK_LIB(gif, PrintGifError, GIFLIB="-lgif",, "-lX11")
+AC_CHECK_LIB(gif, DGifOpen, GIFLIB="-lgif", GIFLIB="")
 if test x"${GIFLIB}" = x; then
 AC_CHECK_LIB(ungif, PrintGifError, GIFLIB="-lungif",, "-lX11")
 fi

--- a/src/blocks/gifdbl.c
+++ b/src/blocks/gifdbl.c
@@ -203,7 +203,11 @@ readGif(GifFileType *file, dblData result)
 	}
 
 	/* Done! */
+#if GIFLIB_MAJOR < 5
 	DGifCloseFile(file);
+#else
+	DGifCloseFile(file, NULL);
+#endif
 
 	result->data = malloc(outsize = (int)floor(size*1.01+12));
 
@@ -227,7 +231,11 @@ SWFDBLBitmapData newSWFDBLBitmapData_fromGifFile(const char *fileName)
 	SWFDBLBitmapData ret;
 	struct dbl_data gifdata;
 
+#if GIFLIB_MAJOR >= 5
+	if((file = DGifOpenFileName(fileName, NULL)) == NULL)
+#else
 	if((file = DGifOpenFileName(fileName)) == NULL)
+#endif
 		return NULL;
 	if(!readGif(file, &gifdata))
 		return NULL;
@@ -246,7 +254,11 @@ SWFDBLBitmapData newSWFDBLBitmapData_fromGifInput(SWFInput input)
 	SWFDBLBitmapData ret;
 	struct dbl_data gifdata;
 
+#if GIFLIB_MAJOR >= 5
+	if((file = DGifOpen(input, (InputFunc) gifReadFunc, NULL)) == NULL)
+#else
 	if((file = DGifOpen(input, (InputFunc) gifReadFunc)) == NULL)
+#endif
 		return NULL;
 	if(!readGif(file, &gifdata))
 		return NULL;

--- a/src/libming.h
+++ b/src/libming.h
@@ -75,12 +75,20 @@ typedef unsigned char BOOL;
   #include <unistd.h>
 #endif
 
-#if GIFLIB_GIFERRORSTRING
+#ifdef HAVE_GIF_LIB_H
 #include <gif_lib.h>
 static void
 PrintGifError(void)
 {
-	fprintf(stderr, "\nGIF-LIB error: %s.\n", GifErrorString());
+#if GIFLIB_GIFERRORSTRING
+#if GIFLIB_MAJOR < 5
+       fprintf(stderr, "\nGIF-LIB error: %s.\n", GifErrorString());
+#else
+       fprintf(stderr, "\nGIF-LIB error: %s.\n", GifErrorString(0));
+#endif
+#else
+       fprintf(stderr, "\nGIF-LIB error but no GifErrorString support.\n");
+#endif
 }
 #endif
 

--- a/util/gif2dbl.c
+++ b/util/gif2dbl.c
@@ -22,7 +22,9 @@
 void error(char *msg)
 {
   printf("%s:\n\n", msg);
+#if GIFLIB_MAJOR < 5
   PrintGifError();
+#endif
   exit(-1);
 }
 
@@ -59,8 +61,15 @@ unsigned char *readGif(char *fileName, int *length, int *bytesPerColor)
   unsigned char *p;
   int i, nColors, size, alpha, bgColor, alignedWidth;
 
+#if GIFLIB_MAJOR >= 5
+  int errorCode = 0;
+
+  if((file = DGifOpenFileName(fileName, &errorCode)) == NULL)
+    error(GifErrorString(errorCode));
+#else
   if((file = DGifOpenFileName(fileName)) == NULL)
     error("Error opening file");
+#endif
 
   if(DGifSlurp(file) != GIF_OK)
     error("Error slurping file");
@@ -190,7 +199,11 @@ unsigned char *readGif(char *fileName, int *length, int *bytesPerColor)
   }
 
 	/* Done! */
+#if GIFLIB_MAJOR < 5
   DGifCloseFile(file);
+#else
+  DGifCloseFile(file, NULL);
+#endif
 
   *length = size;
   return data;

--- a/util/gif2mask.c
+++ b/util/gif2mask.c
@@ -16,7 +16,9 @@
 void error(char *msg)
 {
   printf("%s:\n\n", msg);
+#if GIFLIB_MAJOR < 5
   PrintGifError();
+#endif
   exit(-1);
 }
 
@@ -28,8 +30,15 @@ unsigned char *readGif(char *fileName, int *length)
   unsigned char *data;
   int i, nColors, size;
 
+#if GIFLIB_MAJOR < 5
   if((file = DGifOpenFileName(fileName)) == NULL)
     error("Error opening file");
+#else
+  int errorCode = 0;
+
+  if((file = DGifOpenFileName(fileName, &errorCode)) == NULL)
+    error(GifErrorString(errorCode));
+#endif
 
   if(DGifSlurp(file) != GIF_OK)
     error("Error slurping file");


### PR DESCRIPTION
This still works with giflib-4.

I'm not familiar with this library, so please review carefully. I passed NULL to DGifCloseFile for the errorcode pointer for the giflib-5 API (passing NULL looks compatible, see http://sourceforge.net/p/giflib/code/ci/master/tree/lib/dgif_lib.c#l613) and an error code of "0" to GifErrorString, cause I didn't know what else to pass there.