### PR TITLE
Support building against giflib 5.1.1.

### DIFF
--- a/src/blocks/gifdbl.c
+++ b/src/blocks/gifdbl.c
@@ -203,7 +203,12 @@ readGif(GifFileType *file, dblData result)
 	}
 
 	/* Done! */
+#if GIFLIB_MAJOR >= 5 && GIFLIB_MINOR >= 1
+	if (DGifCloseFile(file, NULL) != GIF_OK)
+	    return 0;
+#else
 	DGifCloseFile(file);
+#endif
 
 	result->data = malloc(outsize = (int)floor(size*1.01+12));
 
@@ -227,7 +232,11 @@ SWFDBLBitmapData newSWFDBLBitmapData_fromGifFile(const char *fileName)
 	SWFDBLBitmapData ret;
 	struct dbl_data gifdata;
 
+#if GIFLIB_MAJOR >= 5
+	if((file = DGifOpenFileName(fileName, NULL)) == NULL)
+#else
 	if((file = DGifOpenFileName(fileName)) == NULL)
+#endif
 		return NULL;
 	if(!readGif(file, &gifdata))
 		return NULL;
@@ -246,7 +255,11 @@ SWFDBLBitmapData newSWFDBLBitmapData_fromGifInput(SWFInput input)
 	SWFDBLBitmapData ret;
 	struct dbl_data gifdata;
 
+#if GIFLIB_MAJOR >= 5
+	if((file = DGifOpen(input, (InputFunc) gifReadFunc, NULL)) == NULL)
+#else
 	if((file = DGifOpen(input, (InputFunc) gifReadFunc)) == NULL)
+#endif
 		return NULL;
 	if(!readGif(file, &gifdata))
 		return NULL;

--- a/src/libming.h
+++ b/src/libming.h
@@ -75,13 +75,38 @@ typedef unsigned char BOOL;
   #include <unistd.h>
 #endif
 
-#if GIFLIB_GIFERRORSTRING
+#ifdef HAVE_GIF_LIB_H
 #include <gif_lib.h>
-static void
-PrintGifError(void)
-{
-	fprintf(stderr, "\nGIF-LIB error: %s.\n", GifErrorString());
-}
 #endif
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if (defined(__GNUC__)) || __has_attribute(unused)
+#define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#define UNUSED(x) UNUSED_ ## x
+#endif
+
+#if GIFLIB_MAJOR < 5
+#define GIFLIB5_ONLY(x) UNUSED(x)
+#else
+#define GIFLIB5_ONLY(x) x
+#endif
+
+static void
+PrintGifError(int GIFLIB5_ONLY(errorCode))
+{
+#if GIFLIB_GIFERRORSTRING
+#if GIFLIB_MAJOR < 5
+	fprintf(stderr, "\nGIF-LIB error: %s.\n", GifErrorString());
+#else
+	fprintf(stderr, "\nGIF-LIB error: %s.\n", GifErrorString(errorCode));
+#endif
+#else
+	fprintf(stderr, "\nGIF-LIB error but no GifErrorString support.\n");
+#endif
+}
 
 #endif /* SWF_LIBMING_H_INCLUDED */

--- a/util/gif2mask.c
+++ b/util/gif2mask.c
@@ -13,10 +13,10 @@
 
 #define max(a,b,c) (((a)>(b))?(((c)>(a))?(c):(a)):(((c)>(b))?(c):(b)))
 
-void error(char *msg)
+void error(char *msg, int errorCode)
 {
   printf("%s:\n\n", msg);
-  PrintGifError();
+  PrintGifError(errorCode);
   exit(-1);
 }
 
@@ -28,11 +28,22 @@ unsigned char *readGif(char *fileName, int *length)
   unsigned char *data;
   int i, nColors, size;
 
+#if GIFLIB_MAJOR < 5
   if((file = DGifOpenFileName(fileName)) == NULL)
-    error("Error opening file");
+    error("Error opening file", 0);
+#else
+  int errorCode = 0;
+
+  if((file = DGifOpenFileName(fileName, &errorCode)) == NULL)
+    error("Error opening file", errorCode);
+#endif
 
   if(DGifSlurp(file) != GIF_OK)
-    error("Error slurping file");
+#if GIFLIB_MAJOR < 5
+    error("Error slurping file", 0);
+#else
+    error("Error slurping file", file->Error);
+#endif
 
   /* data should now be available */
 


### PR DESCRIPTION
Updated version of my patch from https://github.com/libming/libming/pull/43 which now also works with giflib 5.1.x (DGifCloseFile was changed between 5.0 and 5.1)

In GifLib 5, the code was changed to provide error values in a thread-safe way. They are either stored in the Error field of the GifFile, if one is used, or passed to the function in other cases. It is the latter that changes the signature of a number of functions.
