### PR TITLE
Adjusting java_ext author email address and removing separate java_ext license

### DIFF
--- a/java_ext/README
+++ b/java_ext/README
@@ -1,15 +1,9 @@
 LICENSE
 --------
 
-This software is copyright 2001 E-Publishing Group Inc.  Permission is granted
-to use the code and/or make changes to the code provided that the original
-copyright and author attribution is included in each file. 
+Copyright (c) 2001 Jonathan Shore
 
-The license does not make any warranty of liability, merchantability, or
-fitness for any specific purpose.
-
-Please contact the author <jshore@e-shuppan.com> if you have any questions
-about the license or the software.
+Please refer to the project LICENSE file.
 
 
 BUILDING
@@ -79,4 +73,4 @@ Please contact me if you would like more information about this.
 CONTACT
 -------
 
-Jonathan Shore <jshore@e-shuppan.com>
+Jonathan Shore <jonathan.shore@gmail.com>

--- a/java_ext/README
+++ b/java_ext/README
@@ -3,7 +3,7 @@ LICENSE
 
 Copyright (c) 2001 Jonathan Shore
 
-Please refer to the project LICENSE file.
+Please refer to the project libming LICENSE file.
 
 
 BUILDING

--- a/java_ext/README.md
+++ b/java_ext/README.md
@@ -1,14 +1,4 @@
-LICENSE
---------
-
-Copyright (c) 2001 Jonathan Shore
-
-Please refer to the project libming LICENSE file.
-
-
-BUILDING
---------
-
+# Building 
 Build the java library and the native library, running make in the java 
 directory (the current directory) and "native" directory respectively.
 
@@ -18,23 +8,20 @@ placed anywhere (I typically put it in the same installation directory as
 my jar files).
 
 
-USING IT
---------
-
+# Using It
 To compile or run against this library should do the following (csh):
 
+```sh
    setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:<directory-with-.so-files>
 
    java or javac -classpath <old-path>:<jar dir>/jswf.jar
-
+```
 
 Make sure you also include libming.so in the directory with your libjswf.so.
 Alternatively, add the ming library to your LD_LIBRARY_PATH.
 
 
-NOTES
------
-
+# Notes
 The Java class heirarchy and methods closely mirror the PHP and python
 interfaces. I've added some additional convenience functions and new
 functionality.
@@ -44,33 +31,16 @@ makes browsing the API easier and also allows for other implementations.
 Methods that result SWF objects will return SWF interfaces rather than the 
 explicit objects.  For example:
 
+```Java
 	SWFMovie movie = new SWFMovie();
 	...
 	SWFDisplayItemI item = movie.add (shape);
 	item.moveTo (23,30);
-
-The add method returns SWFDisplayItemI rather than SWFDisplayItem.  No big
+```
+	
+The add method returns ```SWFDisplayItemI``` rather than ```SWFDisplayItem```.  No big
 deal.  Just be aware that interfaces (identified with an "I" suffix) are
 used most of the time.
 
-
-EXTENDED API
-------------
-
-If you are interested in more advanced functionality, we have a not-yet 
-publicly available high-level API built on top of this.  Currently includes
-the following:
-
-  - supports wide variety of image formats (ming only supports jpeg and dbl)
-  - timeline & animation classes
-  - text and object align to arbitrary paths (and path animation)
-  - movie (mpeg, qt, avi, etc) to flash (in progress)
-  - others
-
-Please contact me if you would like more information about this.
-
-
-CONTACT
--------
-
+# Contact
 Jonathan Shore <jonathan.shore@gmail.com>

--- a/java_ext/SWFAction.java
+++ b/java_ext/SWFAction.java
@@ -3,15 +3,11 @@
 //    SWFAction Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFActionI.java
+++ b/java_ext/SWFActionI.java
@@ -3,15 +3,11 @@
 //    SWFAction Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFBitmap.java
+++ b/java_ext/SWFBitmap.java
@@ -3,15 +3,11 @@
 //    SWFBitmap Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFBitmapI.java
+++ b/java_ext/SWFBitmapI.java
@@ -3,15 +3,11 @@
 //    SWFBitmap Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFButton.java
+++ b/java_ext/SWFButton.java
@@ -3,15 +3,11 @@
 //    SWFButton Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFButtonI.java
+++ b/java_ext/SWFButtonI.java
@@ -3,15 +3,11 @@
 //    SWFButton Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFColor.java
+++ b/java_ext/SWFColor.java
@@ -3,14 +3,11 @@
 //    SWFColor Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
+//    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for any specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFDimensionableI.java
+++ b/java_ext/SWFDimensionableI.java
@@ -3,14 +3,11 @@
 //    SWFDimensionable Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
+//    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFDisplayItem.java
+++ b/java_ext/SWFDisplayItem.java
@@ -3,19 +3,12 @@
 //    SWFDisplayItem Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
+//    Copyright 2001 Jonathan Shore
 //
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
-//
-
-
-
 
 
 

--- a/java_ext/SWFDisplayItemI.java
+++ b/java_ext/SWFDisplayItemI.java
@@ -3,15 +3,11 @@
 //    SWFDisplayItem Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFException.java
+++ b/java_ext/SWFException.java
@@ -3,19 +3,12 @@
 //    SWFException Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
+//    Copyright 2001 Jonathan Shore
 //
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
-//
-
-
-
 
 
 

--- a/java_ext/SWFFill.java
+++ b/java_ext/SWFFill.java
@@ -3,15 +3,11 @@
 //    SWFFill Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFFillI.java
+++ b/java_ext/SWFFillI.java
@@ -3,15 +3,11 @@
 //    SWFFill Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFFont.java
+++ b/java_ext/SWFFont.java
@@ -3,15 +3,11 @@
 //    SWFFont Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFFontI.java
+++ b/java_ext/SWFFontI.java
@@ -3,15 +3,11 @@
 //    SWFFont Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFGradient.java
+++ b/java_ext/SWFGradient.java
@@ -3,15 +3,11 @@
 //    SWFGradientI Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFGradientI.java
+++ b/java_ext/SWFGradientI.java
@@ -3,15 +3,11 @@
 //    SWFGradient Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFMatrix.java
+++ b/java_ext/SWFMatrix.java
@@ -3,14 +3,11 @@
 //    SWFMatrix Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
+//    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for any specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFMorph.java
+++ b/java_ext/SWFMorph.java
@@ -3,15 +3,11 @@
 //    SWFMorph Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFMorphI.java
+++ b/java_ext/SWFMorphI.java
@@ -3,20 +3,12 @@
 //    SWFMorph Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
+//    Copyright 2001 Jonathan Shore
 //
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
-//
-
-
-
-
 
 
 

--- a/java_ext/SWFMovie.java
+++ b/java_ext/SWFMovie.java
@@ -3,15 +3,11 @@
 //    SWFMovie Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFMovieClip.java
+++ b/java_ext/SWFMovieClip.java
@@ -3,15 +3,11 @@
 //    SWFMovieClip Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFMovieClipI.java
+++ b/java_ext/SWFMovieClipI.java
@@ -3,15 +3,11 @@
 //    SWFMovieClip Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFMovieI.java
+++ b/java_ext/SWFMovieI.java
@@ -3,15 +3,11 @@
 //    SWFMovie Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFObject.java
+++ b/java_ext/SWFObject.java
@@ -3,15 +3,11 @@
 //    SWFObject Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFObjectI.java
+++ b/java_ext/SWFObjectI.java
@@ -3,15 +3,11 @@
 //    SWFObject Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for any specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFShape.java
+++ b/java_ext/SWFShape.java
@@ -3,15 +3,11 @@
 //    SWFShape Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFShapeI.java
+++ b/java_ext/SWFShapeI.java
@@ -3,15 +3,11 @@
 //    SWFShape Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFSound.java
+++ b/java_ext/SWFSound.java
@@ -3,15 +3,11 @@
 //    SWFSound Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFSoundI.java
+++ b/java_ext/SWFSoundI.java
@@ -3,15 +3,11 @@
 //    SWFSound Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFText.java
+++ b/java_ext/SWFText.java
@@ -3,15 +3,11 @@
 //    SWFText Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFTextField.java
+++ b/java_ext/SWFTextField.java
@@ -3,15 +3,11 @@
 //    SWFTextField Class
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFTextFieldI.java
+++ b/java_ext/SWFTextFieldI.java
@@ -3,15 +3,11 @@
 //    SWFTextField Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/SWFTextI.java
+++ b/java_ext/SWFTextI.java
@@ -3,15 +3,11 @@
 //    SWFText Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warranty of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFAction.h
+++ b/java_ext/native/SWFAction.h
@@ -3,15 +3,11 @@
 //    SWFAction Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFBitmap.h
+++ b/java_ext/native/SWFBitmap.h
@@ -3,15 +3,11 @@
 //    SWFBitmap Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFButton.h
+++ b/java_ext/native/SWFButton.h
@@ -3,15 +3,11 @@
 //    SWFButton Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFDisplayItem.h
+++ b/java_ext/native/SWFDisplayItem.h
@@ -3,15 +3,11 @@
 //    SWFDisplayItem Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFFill.h
+++ b/java_ext/native/SWFFill.h
@@ -3,15 +3,11 @@
 //    SWFFill Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFFont.h
+++ b/java_ext/native/SWFFont.h
@@ -3,15 +3,11 @@
 //    SWFFont Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFGradient.h
+++ b/java_ext/native/SWFGradient.h
@@ -3,15 +3,11 @@
 //    SWFGradient Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFMorph.h
+++ b/java_ext/native/SWFMorph.h
@@ -3,15 +3,11 @@
 //    SWFMorph Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFMovie.h
+++ b/java_ext/native/SWFMovie.h
@@ -3,15 +3,11 @@
 //    SWFMovie Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFMovieClip.h
+++ b/java_ext/native/SWFMovieClip.h
@@ -3,15 +3,11 @@
 //    SWFMovieClip Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFNative.h
+++ b/java_ext/native/SWFNative.h
@@ -3,15 +3,11 @@
 //    SWFNative Implementation
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFShape.h
+++ b/java_ext/native/SWFShape.h
@@ -3,15 +3,11 @@
 //    SWFShape Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFSound.h
+++ b/java_ext/native/SWFSound.h
@@ -3,15 +3,12 @@
 //    SWFSound Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    krechert
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 #include <jni.h>
@@ -22,6 +19,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+  
 /*
  * Class:     SWFSound
  * Method:    nNew

--- a/java_ext/native/SWFText.h
+++ b/java_ext/native/SWFText.h
@@ -3,15 +3,11 @@
 //    SWFText Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFTextField.h
+++ b/java_ext/native/SWFTextField.h
@@ -3,15 +3,11 @@
 //    SWFTextField Native Interface
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 

--- a/java_ext/native/SWFUtilities.h
+++ b/java_ext/native/SWFUtilities.h
@@ -3,15 +3,11 @@
 //    SWFUtilities Implementation
 //
 // Authors:
-//    Jonathan Shore <jshore@e-shuppan.com>
+//    Jonathan Shore <jonathan.shore@gmail.com>
 //    Based on php wrapper developed by <dave@opaque.net>
 //
 // Copyright:
-//    Copyright 2001 E-Publishing Group Inc.  Permission is granted to use or
-//    modify this code provided that the original copyright notice is included.
-//
-//    This software is distributed with no warrantee of liability, merchantability,
-//    or fitness for a specific purpose.
+//    Copyright 2001 Jonathan Shore
 //
 
 


### PR DESCRIPTION
I am the author of the java_ext part of the libming package.  At the time had a different email address and was released under LGPL.  Removed my old licensing so that would just be under the umbrella of libming.   I also adjusted my email address.