### PR TITLE
Fix various overflows in OpCode and readBytes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@
 
   * Fix potential DOS in decompilers (CVS-2017-8782, issue #70)
   * Fix various overflows in util/ (CVE-2017-11704)
+  * Fix various overflows in OpCode and readBytes (CVE-2017-11728, CVE-2017-11729,
+    CVE-2017-11730 and CVE-2017-11731).
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -864,7 +864,13 @@ static inline int OpCode(SWF_ACTION *actions, int n, int maxn)
 		SWF_warn("OpCode: want %i, max %i\n", n, maxn);
 #endif
 		return -999;
-	}
+	} else if (n < 1) {
+
+#if DEBUG
+		SWF_warn("OpCode: want %i < 1\n", n);
+#endif
+		return -998;
+        }
 	return actions[n].SWF_ACTIONRECORD.ActionCode;
 }
 

--- a/util/read.c
+++ b/util/read.c
@@ -226,6 +226,14 @@ float readFloat(FILE *f)
 
 char *readBytes(FILE *f,int size)
 {
+
+  if (size < 1) {
+#if DEBUG
+    SWF_warn("readBytes: want to read %i < 1 bytes: Handling a 0\n", size);
+#endif
+    size = 0;
+  }
+
   int i;
   char *buf;
 


### PR DESCRIPTION
* _OpCode_: Add a check to avoid reading the stack when n < 1.
  In this case, print a debug warning and return error code -998

* _readBytes_: When size < 0, set it to zero (don't read anything) and print a warning

This commit fixes CVE-2017-117{28,29,30} (#82, #81 and #79).