### PR TITLE
Fix heap buffer overflow in decompileCALLFUNCTION

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@
   * Fix various overflows in OpCode and readBytes (CVE-2017-11728,
     CVE-2017-11729, CVE-2017-11730 and CVE-2017-11731, issues #79,
     #81, #81 and #84).
+  * Fix heap buffer overflow in decompileCALLFUNCTION (CVE-2017-11734,
+    issue #83).
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -2873,7 +2873,7 @@ decompileCALLFUNCTION(int n, SWF_ACTION *actions, int maxn)
 	struct SWF_ACTIONPUSHPARAM *meth, *nparam;
 
 	SanityCheck(SWF_CALLMETHOD,
-		actions[n-1].SWF_ACTIONRECORD.ActionCode == SWFACTION_PUSH,
+		n > 0 && actions[n-1].SWF_ACTIONRECORD.ActionCode == SWFACTION_PUSH,
 		"CALLMETHOD not preceeded by PUSH")
 
 	meth=pop();


### PR DESCRIPTION
Make sure that n > 1 before checking for the previous action in the actions array, otherwise an overflow may occur.

This PR fixes CVE-2017-11734 (fixes #83).