### PR TITLE
Add checks to avoid null pointer dereference in util/parser.c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@
     #81, #81 and #84).
   * Fix heap buffer overflow in decompileCALLFUNCTION (CVE-2017-11734,
     issue #83).
+  * Add checks to avoid null pointer dereference in util/parser.c
+    (CVE-2017-9988, issue #85)
 
 0.4.8 - 2017-04-07
 

--- a/util/parser.c
+++ b/util/parser.c
@@ -3079,6 +3079,10 @@ void parseABC_NS_SET_INFO(struct ABC_NS_SET_INFO *nsset, FILE *f)
   int i;
   nsset->Count = readEncUInt30(f);
   nsset->NS = malloc(sizeof(U30) * nsset->Count);
+  if (nsset->NS == NULL) {
+    SWF_error("parseABC_NS_SET_INFO: Failed to allocate %lu bytes", sizeof(U30) * nsset->Count);
+    return;
+  }
   for(i = 0; i < nsset->Count; i++)
     nsset->NS[i] = readEncUInt30(f);
 }


### PR DESCRIPTION
Make sure that nsset->NS isn't dereferenced if malloc failed. In this case, report error and abort.

This commit fixes CVE-2017-9988 (fixes #85).