### PR TITLE
Fix various flaws in readBytes (overflow, possible null pointer dereference)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@
     issue #83).
   * Add checks to avoid null pointer dereference in util/parser.c
     (CVE-2017-9988, issue #85)
+  * Change type of size variable in readBytes (int->unsigned long) to
+    avoid overflow when passing U30 integers (CVE-2017-9989, issue #86).
 
 0.4.8 - 2017-04-07
 

--- a/util/read.c
+++ b/util/read.c
@@ -224,17 +224,17 @@ float readFloat(FILE *f)
 }
 
 
-char *readBytes(FILE *f,int size)
+char *readBytes(FILE *f, unsigned long size)
 {
 
   if (size < 1) {
 #if DEBUG
-    SWF_warn("readBytes: want to read %i < 1 bytes: Handling a 0\n", size);
+    SWF_warn("readBytes: want to read %lu < 1 bytes: Handling a 0\n", size);
 #endif
     size = 0;
   }
 
-  int i;
+  unsigned long i;
   char *buf;
 
   buf = (char *)malloc(sizeof(char)*size);

--- a/util/read.c
+++ b/util/read.c
@@ -239,6 +239,11 @@ char *readBytes(FILE *f, unsigned long size)
 
   buf = (char *)malloc(sizeof(char)*size);
 
+  if (buf == NULL) {
+    fprintf(stderr, "readBytes: Failed to allocate %lu bytes", sizeof(char) * size);
+    exit(-1);
+  }
+
   for(i=0;i<size;i++)
   {
     buf[i]=(char)readUInt8(f);

--- a/util/read.h
+++ b/util/read.h
@@ -20,7 +20,7 @@ long readSInt32(FILE *f);
 unsigned long readEncUInt32(FILE *f);
 unsigned long readEncUInt30(FILE *f);
 long readEncSInt32(FILE *f);
-char *readBytes(FILE *f,int size);
+char *readBytes(FILE *f,unsigned long size);
 char *readString(FILE *f);
 char *readSizedString(FILE *f,int size);
 double readDouble(FILE *f);


### PR DESCRIPTION
* Change type of `size` variable in readBytes:

`size` should have type `unsigned long` instead of `int` in order to avoid overflows and lossy casts when passing `U30` integers.

* Avoid NULL pointer dereference in readBytes:

Make sure that `buf` isn't dereferenced if malloc failed. In this case, report error and abort.

Two commits because 847b989 isn't directly related to CVE-2017-9989.