### PR TITLE
Fix various issues related to CVE-2017-11733.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@
   * Rewrite readSInt16, readUInt16 and readSInt32 (util/read.h) to avoid
     undefined behavior (order of evaluation is not guaranteed in the C
     standard).
+  * Un-define DEBUGSTACK in util/decompile.c (return cleanly when stack
+    is NULL).
 
 0.4.8 - 2017-04-07
 

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@
     (CVE-2017-9988, issue #85)
   * Change type of size variable in readBytes (int->unsigned long) to
     avoid overflow when passing U30 integers (CVE-2017-9989, issue #86).
+  * Add checks to avoid processing stackswap when stack only contains
+    one element (CVE-2017-11733, issue #78).
 
 0.4.8 - 2017-04-07
 

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@
     avoid overflow when passing U30 integers (CVE-2017-9989, issue #86).
   * Add checks to avoid processing stackswap when stack only contains
     one element (CVE-2017-11733, issue #78).
+  * Rewrite readSInt16, readUInt16 and readSInt32 (util/read.h) to avoid
+    undefined behavior (order of evaluation is not guaranteed in the C
+    standard).
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -20,7 +20,7 @@
 
 #define _GNU_SOURCE 1
 
-#define DEBUGSTACK
+//#define DEBUGSTACK
 #define DECOMP_SWITCH
 // #define DEBUGSWITCH
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -626,6 +626,14 @@ stackswap()
 #endif
 	struct SWF_ACTIONPUSHPARAM *p = peek();		/* peek() includes error handling */
 	char type = Stack->type;
+
+        if (Stack->next == NULL) {
+#if DEBUG
+		SWF_warn("stackswap: can't swap (stack contains only one element)\n");
+#endif
+                return;
+        }
+
 	Stack->type = Stack->next->type;
 	Stack->val  = Stack->next->val;
 	Stack->next->type = type;

--- a/util/read.c
+++ b/util/read.c
@@ -148,26 +148,38 @@ int readSInt8(FILE *f)
 
 int readSInt16(FILE *f)
 {
-  return readUInt8(f) + readSInt8(f)*256;
+  int result = 0;
+  result |= readUInt8(f);
+  result |= readSInt8(f) << 8;
+  return result;
 }
 
-int readUInt16(FILE *f)
+unsigned int readUInt16(FILE *f)
 {
-  return readUInt8(f) + (readUInt8(f)<<8);
+  unsigned int result = 0u;
+  result |= readUInt8(f);
+  result |= readUInt8(f) << 8;
+  return result;
 }
 
 long readSInt32(FILE *f)
 {
-  return (long)readUInt8(f) + (readUInt8(f)<<8) + (readUInt8(f)<<16) + (readUInt8(f)<<24);
+  long result = 0;
+  result |= readUInt8(f);
+  result |= readUInt8(f) << 8;
+  result |= readUInt8(f) << 16;
+  result |= readUInt8(f) << 24;
+  return result;
 }
 
 unsigned long readUInt32(FILE *f)
 {
-  int part1 = readUInt8(f);
-  int part2 = readUInt8(f) << 8;
-  int part3 = readUInt8(f) << 16;
-  unsigned long part4 = ((unsigned long)readUInt8(f)) << 24;
-  return part1 + part2 + part3 + part4;
+  unsigned long result = 0u;
+  result |= readUInt8(f);
+  result |= readUInt8(f) << 8;
+  result |= readUInt8(f) << 16;
+  result |= readUInt8(f) << 24;
+  return result;
 }
 
 double readDouble(FILE *f)

--- a/util/read.h
+++ b/util/read.h
@@ -13,7 +13,7 @@ int readBits(FILE *f, int number);
 int readSBits(FILE *f, int number);
 int readUInt8(FILE *f);
 int readSInt8(FILE *f);
-int readUInt16(FILE *f);
+unsigned int readUInt16(FILE *f);
 int readSInt16(FILE *f);
 unsigned long readUInt32(FILE *f);
 long readSInt32(FILE *f);


### PR DESCRIPTION
Avoid processing stackswap when stack only contains one element. In this case, print a warning if debug mode is enabled, and return cleanly.

This PR fixes CVE-2017-11733 (fixes #78).

Please note:
* This fix only addresses the null pointer dereference issue. See #78.
* I'm going to update this PR in order to also address the memory leaks issue. I'd suggest to wait before merge.