### PR TITLE
Fix NULL pointer dereference in outputSWF_TEXT_RECORD (CVE-2017-16883)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@
     standard).
   * Un-define DEBUGSTACK in util/decompile.c (return cleanly when stack
     is NULL).
+  * Fix NULL pointer dereference in outputSWF_TEXT_RECORD (CVE-2017-16883,
+    issue #94)
 
 0.4.8 - 2017-04-07
 

--- a/util/outputscript.c
+++ b/util/outputscript.c
@@ -1426,7 +1426,11 @@ outputSWF_TEXT_RECORD (SWF_TEXTRECORD *trec, int level,char *tname,char *buffer,
   if (!trec->StyleFlagHasFont)				/* always check flag before use data */
   {
    fi = fip_current;					/* so cont w current font */
-   id = fi->fontcodeID;					/* trigger next if */
+
+   if (!fi)
+      SWF_warn("outputSWF_TEXT_RECORD: can't process text record: fonts information list is NULL\n");
+   else
+      id = fi->fontcodeID;					/* trigger next if */
   }
   while (fi)
   {


### PR DESCRIPTION
Check for `!fip_current` before dereferencing it in `id = fi->fontcodeID`.

In the == NULL case, print a warning and continue.

This PR addresses CVE-2017-16883 (#77).

The reproducer still triggers some memory leaks due to abrupt end with error message `Not parsing action da length 0`. These memory leaks are a different issue, already reported in #65: the library is [exiting abruptly](https://github.com/libming/libming/blob/master/util/parser.c#L1280) without freeing malloc-ed resources.