### PR TITLE
Fix buffer overflow in dcputs (buffer missing \0)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@
     is NULL).
   * Fix NULL pointer dereference in outputSWF_TEXT_RECORD (CVE-2017-16883,
     issue #94)
+  * Fix heap buffer overflow in dcputs (global buffer missing \0 character)
+    (CVE-2017-11732, issue #80)
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -79,7 +79,7 @@ static char *dcptr=NULL;
 void
 dcinit()
 {
-	strsize=0;
+	strsize = 1; // We start with empty string, i.e. \0
 	strmaxsize=DCSTRSIZE;
 	dcstr=calloc(DCSTRSIZE,1);
 	dcptr=dcstr;


### PR DESCRIPTION
The dcputs function appends passed string at the end of the global string buffer (dcstr), adapting the buffer's size if necessary.

Unfortunately, the strsize variable which holds the global buffer's size is initialized to 0 in dcinit(), which means that no place for the \0 character is reserved. Hence, whenever dcputs tries to strcat a string to the global buffer, a byte may be missing leading to a heap buffer overflow.

This PR addresses this issue (CVE-2017-11732, closes #80).