### PR TITLE
Fix global buffer overflow in printMP3Headers (CVE-2017-16898)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@
     issue #94)
   * Fix heap buffer overflow in dcputs (global buffer missing \0 character)
     (CVE-2017-11732, issue #80)
+  * Fix global buffer overflow in printMP3Headers (invalid bitrate 15 not
+    detected) (CVE-2017-16898, issue #75).
 
 0.4.8 - 2017-04-07
 

--- a/util/listmp3.c
+++ b/util/listmp3.c
@@ -119,6 +119,11 @@ void printMP3Headers(FILE *f)
       error("invalid samplerate index");
     }
 
+    if (bitrate_idx == 15)
+    {
+      error("invalid bitrate 15");
+    }
+
     channels = ((flags & MP3_CHANNEL) == MP3_CHANNEL_MONO) ? 1 : 2;
 
     switch(flags & MP3_VERSION)


### PR DESCRIPTION
The printMP3Headers function in `util/listmp3.c` processes mp3 files without checking their bitrate values. This leads to `bitrate_idx` = 15 being used as index in `mp2l23_bitrate_table[bitrate_idx]` while `mp2l23_bitrate_table` has size 14.

In this PR we add a check rejecting mp3 files declaring invalid bitrates.

This PR fixes CVE-2017-16898 (fixes: #75).