### PR TITLE
Fix various undefined behavior sources in util/read.c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,8 @@
     (CVE-2017-11732, issue #80)
   * Fix global buffer overflow in printMP3Headers (invalid bitrate 15 not
     detected) (CVE-2017-16898, issue #75).
+  * Fix integer overflow vulnerability in util/read.c (out-of-range left
+    shift in readUInt32) (CVE-2018-5251, issue #98)
 
 0.4.8 - 2017-04-07
 

--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,8 @@
     detected) (CVE-2017-16898, issue #75).
   * Fix integer overflow vulnerability in util/read.c (out-of-range left
     shift in readUInt32) (CVE-2018-5251, issue #98)
+  * Fix left shift of a negative value in util/read.c (left shift of a
+    negative value in readSBits) (CVE-2018-5294, issue #97)
 
 0.4.8 - 2017-04-07
 

--- a/util/read.c
+++ b/util/read.c
@@ -107,7 +107,7 @@ int readSBits(FILE *f, int number)
 {
   int num = readBits(f, number);
 
-  if(num & (1<<(number-1)))
+  if(number && num & (1<<(number-1)))
     return num - (1<<number);
   else
     return num;

--- a/util/read.c
+++ b/util/read.c
@@ -168,7 +168,7 @@ long readSInt32(FILE *f)
   result |= readUInt8(f);
   result |= readUInt8(f) << 8;
   result |= readUInt8(f) << 16;
-  result |= readUInt8(f) << 24;
+  result |= (long) readUInt8(f) << 24;
   return result;
 }
 
@@ -178,7 +178,7 @@ unsigned long readUInt32(FILE *f)
   result |= readUInt8(f);
   result |= readUInt8(f) << 8;
   result |= readUInt8(f) << 16;
-  result |= readUInt8(f) << 24;
+  result |= (unsigned long) readUInt8(f) << 24;
   return result;
 }
 


### PR DESCRIPTION
* in `readUInt32` and `readSInt32`: cast the result of `readUInt8(f)` before left shifting by 24 in order to avoid out of range shift.
* In `readSBits`: make sure that `number` isn't 0 before left-shifting by `(number-1)`.

This PR addresses #97 and #98.