### PR TITLE
Fix NULL pointer dereference in outputSWF_TEXT_RECORD (CVE-2018-6315)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@
     shift in readUInt32) (CVE-2018-5251, issue #98)
   * Fix left shift of a negative value in util/read.c (left shift of a
     negative value in readSBits) (CVE-2018-5294, issue #97)
+  * Fix buffer overflow in outputSWF_TEXT_RECORD (CVE-2018-6315, issue #101)
 
 0.4.8 - 2017-04-07
 

--- a/util/outputscript.c
+++ b/util/outputscript.c
@@ -1439,7 +1439,7 @@ outputSWF_TEXT_RECORD (SWF_TEXTRECORD *trec, int level,char *tname,char *buffer,
     fip_current=fi;					/* set current font */
     for(i=0;i<trec->GlyphCount && i<bsize-1 ;i++)	/* byte n-1 will be terminator '\0' */
     {
-     int off=(&(trec->GlyphEntries[i]))->GlyphIndex[0];
+     unsigned long off=(&(trec->GlyphEntries[i]))->GlyphIndex[0];
      if (off<fi->fontcodearrsize)
       buffer[i]=fi->fontcodeptr[off];
      else


### PR DESCRIPTION
In outputSWF_TEXT_RECORD, the array offset is stored in a signed int, while `(&(trec->GlyphEntries[i]))->GlyphIndex[0]` returns an unsigned 32 bit number.

This may lead to an integer overflow when reading the offset from the `GlyphIndex` array, and further to a buffer overflow when doing `buffer[i]=fi->fontcodeptr[off]` with negative off.

In this commit, we change the type of off to unsigned long so we are guaranteed to be able to store 32 unsigned integers.

This commit fixes CVE-2018-6315 (fixes #101).