### PR TITLE
Use OpCode instead of directly accessing actions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,7 @@
   * Fix left shift of a negative value in util/read.c (left shift of a
     negative value in readSBits) (CVE-2018-5294, issue #97)
   * Fix buffer overflow in outputSWF_TEXT_RECORD (CVE-2018-6315, issue #101)
+  * Fix heap-use-after-free in decompileIF (CVE-2018-6359, issue #105)
 
 0.4.8 - 2017-04-07
 

--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@
     negative value in readSBits) (CVE-2018-5294, issue #97)
   * Fix buffer overflow in outputSWF_TEXT_RECORD (CVE-2018-6315, issue #101)
   * Fix heap-use-after-free in decompileIF (CVE-2018-6359, issue #105)
+  * Use OpCode function instead of directly accessing actions array without
+    checks in util/decompile.c. This is potentially avoiding numerous
+    issues similar to #105 or #83.
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -2387,7 +2387,7 @@ decompileIF(int n, SWF_ACTION *actions, int maxn)
 #define SOME_IF_DEBUG 0	/* coders only */
 		int has_else_or_break= ((sact->Actions[sact->numActions-1].SWF_ACTIONRECORD.ActionCode == SWFACTION_JUMP) &&
 			(sact->Actions[sact->numActions-1].SWF_ACTIONJUMP.BranchOffset > 0 )) ? 1:0;
-		int has_lognot=(actions[n-1].SWF_ACTIONRECORD.ActionCode == SWFACTION_LOGICALNOT) ? 1:0;
+		int has_lognot=(OpCode(actions, n-1, maxn) == SWFACTION_LOGICALNOT) ? 1:0;
 		int else_action_cnt=0,is_logor=0,is_logand=0,sbi,sbe;
 
 		/* before emitting any "if"/"else" characters let's check 


### PR DESCRIPTION
Instead of directly accessing the actions array without checks for the value of n (which may lead to heap buffer overflow etc, see #83 or #105), use the dedicated OpCode function.

This PR fixes #105 (CVE-2018-6359).