### PR TITLE
Fix various issues with pool management / access

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,9 @@
   * Fix heap buffer overflow in listfdb.c (issue #104).
   * Fix code duplication issue in listfdb (issues #106 and #107).
   * Fix various compiler warnings.
+  * Fix heap buffer overflows happening when accessing the constant pool in
+    decompile.c (CVE-2018-7875, CVE-2018-7871, CVE-2018-7870, CVE-2018-7872,
+    CVE-2018-7868, issues #112, #113, #114, #117, #120, #122 and #123).
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -46,6 +46,7 @@
 
 
 static char **pool;
+static unsigned short poolcounter;
 struct SWF_ACTIONPUSHPARAM *regs[256];
 
 static char *getName(struct SWF_ACTIONPUSHPARAM *act);
@@ -346,12 +347,22 @@ getString(struct SWF_ACTIONPUSHPARAM *act)
 		sprintf(t,"%ld", act->p.Integer );
 		return t;
 	case PUSH_CONSTANT: /* CONSTANT8 */
+		if (act->p.Constant8 > poolcounter)
+		{
+		        SWF_warn("WARNING: retrieving constants not present in the pool.\n");
+		        break;
+		}
 		t=malloc(strlenext(pool[act->p.Constant8])+3); /* 2 "'"s and a NULL */
 		strcpy(t,"'");
 		strcatext(t,pool[act->p.Constant8]);
 		strcat(t,"'");
 		return t;
 	case PUSH_CONSTANT16: /* CONSTANT16 */
+		if (act->p.Constant16 > poolcounter)
+		{
+		        SWF_warn("WARNING: retrieving constants not present in the pool.\n");
+		        break;
+		}
 		t=malloc(strlenext(pool[act->p.Constant16])+3); /* 2 '\"'s and a NULL */
 		strcpy(t,"'");
 		strcatext(t,pool[act->p.Constant16]);
@@ -366,7 +377,11 @@ getString(struct SWF_ACTIONPUSHPARAM *act)
 		fprintf (stderr,"  Can't get string for type: %d\n", act->Type);
 		break;
 	}
-	return "";
+
+	t = malloc(sizeof(char));
+	strcpyext(t,"");
+
+	return t;
 }
 
 static char *
@@ -395,6 +410,11 @@ getName(struct SWF_ACTIONPUSHPARAM *act)
   		return t;
 #endif
 	case PUSH_CONSTANT: /* CONSTANT8 */
+		if (act->p.Constant8 > poolcounter)
+		{
+		        SWF_warn("WARNING: retrieving constants not present in the pool.\n");
+		        break;
+		}
 		t=malloc(strlenext(pool[act->p.Constant8])+1);
 		strcpyext(t,pool[act->p.Constant8]);
 		if(strlen(t)) /* Not a zero length string */
@@ -405,6 +425,11 @@ getName(struct SWF_ACTIONPUSHPARAM *act)
 			return strcpy(t,"this");
 		}
 	case PUSH_CONSTANT16: /* CONSTANT16 */
+		if (act->p.Constant16 > poolcounter)
+		{
+		        SWF_warn("WARNING: retrieving constants not present in the pool.\n");
+		        break;
+		}
 		t=malloc(strlenext(pool[act->p.Constant16])+1);
 		strcpyext(t,pool[act->p.Constant16]);
 		if(strlen(t)) /* Not a zero length string */
@@ -417,6 +442,11 @@ getName(struct SWF_ACTIONPUSHPARAM *act)
 	default: 
 		return getString(act);
 	}
+
+	t = malloc(sizeof(char));
+	strcpyext(t,"");
+
+	return t;
 }
 
 static int
@@ -736,6 +766,7 @@ decompileCONSTANTPOOL (SWF_ACTION *act)
 {
 	OUT_BEGIN(SWF_ACTIONCONSTANTPOOL);
 	pool=sact->ConstantPool;
+	poolcounter = sact->Count;
 }
 
 static void
@@ -793,12 +824,22 @@ decompilePUSHPARAM (struct SWF_ACTIONPUSHPARAM *act, int wantstring)
 
 #if 0
 	  case 8: /* CONSTANT8 */
+		if (act->p.Constant8 > poolcounter)
+		{
+		        SWF_warn("WARNING: retrieving constants not present in the pool.\n");
+		        break;
+		}
 		if( wantstring )
   		  printf ("'%s'", pool[act->p.Constant8]);
 		else
   		  printf ("%s", pool[act->p.Constant8]);
 		break;
 	  case 9: /* CONSTANT16 */
+		if (act->p.Constant16 > poolcounter)
+		{
+		        SWF_warn("WARNING: retrieving constants not present in the pool.\n");
+		        break;
+		}
 		if( wantstring )
   		  printf ("'%s'", pool[act->p.Constant16]);
 		else
@@ -3429,6 +3470,7 @@ decompile5Action(int n, SWF_ACTION *actions,int indent)
 		return NULL;
 
 	pool = NULL;
+	poolcounter = 0;
 
 	dcinit();
 


### PR DESCRIPTION
Constants are usually retrieved from the constant pool without verifying that the pool actually contains them, which may lead to various heap buffer overflow issues.

In this PR we add a counter keeping track of how many elements the pool contains, and checks making sure that whenever the pool is accessed, the constant in present in the pool (constant position < pool counter).

Also, do not return "" when a pointer is excepted (it should be legal to free this return value).

This PR fixes #112 (CVE-2018-7875), fixes #120 (CVE-2018-7871), fixes #117 (CVE-2018-7870), fixes #114 (CVE-2018-7872), fixes #122, fixes #113 (CVE-2018-7868), fixes #123.

Lots of non trivial stuff here, careful review would be really helpful.