### PR TITLE
Fix null pointer dereference in getName/getString

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -41,6 +41,7 @@
     CVE-2018-7868, issues #112, #113, #114, #117, #120, #122 and #123).
   * Fix NULL pointer dereference happening when calling getName and getString
     with empty acts (NULL act->p.String) (issue #121).
+  * Fix heap-buffer-overflow in getString (CVE-2018-7867, issue #116).
 
 0.4.8 - 2017-04-07
 

--- a/NEWS
+++ b/NEWS
@@ -40,7 +40,8 @@
     decompile.c (CVE-2018-7875, CVE-2018-7871, CVE-2018-7870, CVE-2018-7872,
     CVE-2018-7868, issues #112, #113, #114, #117, #120, #122 and #123).
   * Fix NULL pointer dereference happening when calling getName and getString
-    with empty acts (NULL act->p.String) (issue #121).
+    with empty acts (NULL act->p.String). Perform deep copy in pushdup,
+    instead of shallow copy (issue #121).
   * Fix heap-buffer-overflow in getString (CVE-2018-7867, issue #116).
 
 0.4.8 - 2017-04-07

--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,8 @@
   * Fix heap buffer overflows happening when accessing the constant pool in
     decompile.c (CVE-2018-7875, CVE-2018-7871, CVE-2018-7870, CVE-2018-7872,
     CVE-2018-7868, issues #112, #113, #114, #117, #120, #122 and #123).
+  * Fix NULL pointer dereference happening when calling getName and getString
+    with empty acts (NULL act->p.String) (issue #121).
 
 0.4.8 - 2017-04-07
 

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -311,6 +311,11 @@ getString(struct SWF_ACTIONPUSHPARAM *act)
 	switch( act->Type ) 
 	{
 	case PUSH_STRING: 
+		if (!act->p.String) /* Not a NULL string */
+		{
+		        SWF_warn("WARNING: Call to getString with NULL string.\n");
+		        break;
+		}
 		t=malloc(strlen(act->p.String)+3); /* 2 "'"s and a NULL */
 		strcpy(t,"'");
 		strcat(t,act->p.String);
@@ -392,17 +397,24 @@ getName(struct SWF_ACTIONPUSHPARAM *act)
 	switch( act->Type ) 	
 	{
 	case PUSH_STRING: /* STRING */
-		t=malloc(strlen(act->p.String)+3); 
-		/*
-		strcpy(t,"\"");
-		strcat(t,act->p.String);
-		strcat(t,"\"");
-		*/
-		strcpy(t,act->p.String);
-		if(strlen(t)) /* Not a zero length string */
-			return t;
+		if (!act->p.String) /* Not a NULL string */
+		{
+		        SWF_warn("WARNING: Call to getName with NULL string.\n");
+		        break;
+		}
+		else if (strlen(act->p.String)) /* Not a zero length string */
+		{
+		        t=malloc(strlen(act->p.String)+3);
+		        strcpyext(t,act->p.String);
+		        return t;
+		}
 		else
-			return "this";
+		{
+		        char *return_string = "this";
+	                t=malloc(strlen(return_string)+1); /* string length + \0 */
+	                strcpyext(t,return_string);
+			return t;
+		}
 #if 0
 	  case 4: /* REGISTER */
                 t=malloc(4); /* Rdd */

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -618,7 +618,19 @@ pushdup()
 	}
 	t = calloc(1,sizeof(*Stack));
 	t->type = Stack->type;
-	t->val =  Stack->val;
+
+	// If element is a string, perform deep copy of Stack->val->p
+	if (Stack->val->Type == PUSH_STRING) {
+		t->val = calloc(1, sizeof(struct SWF_ACTIONPUSHPARAM));
+		*t->val = *Stack->val;
+
+		int len = strlen(Stack->val->p.String) + 1; // NULL terminated
+		t->val->p.String = calloc(len, sizeof(char));
+		strcpy(t->val->p.String, Stack->val->p.String);
+	} else {
+		t->val =  Stack->val;
+	}
+
 	t->next = Stack;
 	Stack = t;
 }

--- a/util/decompile.c
+++ b/util/decompile.c
@@ -334,7 +334,7 @@ getString(struct SWF_ACTIONPUSHPARAM *act)
 		}
 		else
 		{
-			t=malloc(4); /* Rdd */
+			t=malloc(5); /* Rddd */
 			sprintf(t,"R%d", act->p.RegisterNumber );
 			return t;
 		}
@@ -344,9 +344,19 @@ getString(struct SWF_ACTIONPUSHPARAM *act)
 		else
 			return "false";
 	case PUSH_DOUBLE: /* DOUBLE */
-		t=malloc(10); /* big enough? */
-		sprintf(t,"%g", act->p.Double );
+	{
+		char length_finder[1];
+		int needed_length = snprintf(length_finder, 1, "%g", act->p.Double) + 1;
+		if (needed_length <= 0)
+		{
+		        SWF_warn("WARNING: could not evaluate size of buffer (memory issue ?).\n");
+		        break;
+		}
+
+		t = malloc(needed_length);
+		sprintf(t, "%g", act->p.Double );
 		return t;
+	}
 	case PUSH_INT: /* INTEGER */
 		t=malloc(10); /* 32-bit decimal */
 		sprintf(t,"%ld", act->p.Integer );
@@ -417,7 +427,7 @@ getName(struct SWF_ACTIONPUSHPARAM *act)
 		}
 #if 0
 	  case 4: /* REGISTER */
-                t=malloc(4); /* Rdd */
+		t=malloc(5); /* Rddd */
   		sprintf(t,"R%d", act->p.RegisterNumber );
   		return t;
 #endif


### PR DESCRIPTION
Whenever `getString` or `getName` are called with an act such that `act->p.String` is a NULL pointer, a NULL pointer dereference might happen (`strlen(act->p.string)` is called).

In this commit we add checks at the beginning of the `PUSH_STRING` block so that a warning is displayed and an empty string is returned in this case.

This PR (partially) fixes #121. In fact I am still working on another patch which would involve patching `pushdup` to do deep copies instead of shallow copies, but before I will have to analyze the specification in order to be able to clearly state which interpretation is the right one.