### PR TITLE
Use pkg-config to find freetype

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,7 @@ AC_CHECK_LIB(X11, XGetImage, XLIB="-lX11", XLIB="")
 
 AC_ARG_ENABLE(
 [freetype],
-[  --enable-freetype       Enable freetype support (default: enabled)],
+[  --disable-freetype      Disable freetype support (default: enabled)],
 [case "${enableval}" in
   yes) freetype_support=yes ;;
    no) freetype_support=no ;;
@@ -257,26 +257,10 @@ freetype_support=yes)
 
 if test "$freetype_support" = "yes"; then
 	dnl Check for the freetype library
-	AC_ARG_WITH(freetype-config, [  --with-freetype-config=PROG   Use FreeType configuration program PROG], freetype_config=$withval, freetype_config=yes)
-	if test "$freetype_config" = "yes"; then 
-		AC_PATH_PROG(ft_config,freetype-config,no)
-        	if test "$ft_config" = "no"; then
-			echo "To compile ming please install freetype:"
-			echo " as .deb user: sudo apt-get install libfreetype6 libfreetype6-dev"
-			echo ""
-			echo "or disable the freetype configuration option:"
-			echo " --disable-freetype"
-                	AC_MSG_ERROR([Could not detect freetype-config!])
-        	fi
-	else
-        	ft_config="$freetype_config"
-	fi
-
-	FREETYPE_CFLAGS="`$ft_config --cflags`"
-	FREETYPE_LIBS="`$ft_config --libs`"
-
-	AC_SUBST(FREETYPE_LIBS)
-	AC_SUBST(FREETYPE_CFLAGS)
+	PKG_PROG_PKG_CONFIG
+	PKG_CHECK_MODULES(FREETYPE, freetype2, HAS_FREETYPE=true,
+		AC_MSG_ERROR([Could not find freetype])
+	)
 fi
 
 dnl Check for the ungif or gif (new or old) libraries
@@ -334,9 +318,9 @@ if test -n "${ZLIB}" -a -n "${ZLIB_INC}"; then
 	AC_DEFINE([USE_ZLIB], [1], [Use zlib])
 fi
 
-AM_CONDITIONAL(USE_FREETYPE, test x${ft_config} != x)
-if test -n "${ft_config}"; then
-	AC_DEFINE(USE_FREETYPE, [1], [Use freetype library])
+AM_CONDITIONAL(USE_FREETYPE, test x${HAS_FREETYPE} != x)
+if test x${HAS_FREETYPE} = xtrue ; then
+       AC_DEFINE(USE_FREETYPE, [1], [Use freetype library])
 fi
 
 AM_CONDITIONAL(GIFLIB_GIFERRORSTRING, test x"$ac_cv_lib_gif_GifErrorString" = xyes)
@@ -504,10 +488,10 @@ else
 	echo "  ZLIB enabled ($ZLIB)"
 fi
 
-if test x"$ft_config" = "x"; then
+if test x"$HAS_FREETYPE" = "x"; then
 	echo "  Freetype library disabled"
 else
-	echo "  Freetype library enabled ($ft_config)"
+	echo "  Freetype library enabled ($FREETYPE_LIBS)"
 fi
 
 if test x"$GIFLIB" = "x" -o x"$GIFINC" = "x"; then


### PR DESCRIPTION
As of freetype-2.9.1 the freetype-config script has been deprecated and
is no longer shipped by default.