### PR TITLE
fix markdown link in README

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,7 @@
 
 MING THE MODULE
 
-[![Build Status](http://travis-ci.org/libming/libming.png)]
-(http://travis-ci.org/libming/libming)
+[![Build Status](http://travis-ci.org/libming/libming.png)](http://travis-ci.org/libming/libming)
 
 Last updated 09th January 2014.
 


### PR DESCRIPTION
Small fix, links in markdown need to be in one line. At least on GitHub.