### PR TITLE
Refactoring to fix compiler warning and improve performance.

### DIFF
--- a/src/blocks/fromswf.c
+++ b/src/blocks/fromswf.c
@@ -750,31 +750,34 @@ static void fillstyle(TAG tp, int lev)
 
 	alignbits(tp);
 	cod = tp->readc(tp);
-	switch(cod)
-	{	case 0:
-			if(verbose) printf("solid fill:\n");
-			break;
-		case 0x10:
-			if(verbose) printf("linear gradient fill\n");
-			break;
-		case 0x12:
-			if(verbose) printf("radial gradient fill:\n");
-			break;
-		case 0x13:
-			if(verbose) printf("focal gradient fill:\n");
-			break;
-		case 0x40:
-			if(verbose) printf("tiled bitmap fill:\n");
-			break;
-		case 0x41:
-			if(verbose) printf("clipped bitmap fill\n");
-			break;
-		case 0x42:
-			if(verbose) printf("tilled bitmap fill with hard edges\n");
-			break;
-		case 0x43:
-			if(verbose) printf("clipped bitmap fill with hard edges\n");
-			break;
+ 
+ 	if(verbose) {
+		switch(cod)
+		{	case 0:
+				printf("solid fill:\n");
+				break;
+			case 0x10:
+				printf("linear gradient fill\n");
+				break;
+			case 0x12:
+				printf("radial gradient fill:\n");
+				break;
+			case 0x13:
+				printf("focal gradient fill:\n");
+				break;
+			case 0x40:
+				printf("tiled bitmap fill:\n");
+				break;
+			case 0x41:
+				printf("clipped bitmap fill\n");
+				break;
+			case 0x42:
+				printf("tilled bitmap fill with hard edges\n");
+				break;
+			case 0x43:
+				printf("clipped bitmap fill with hard edges\n");
+				break;
+		}
 	}
 	if(cod == 0)
 		if(lev >= 3) rgba((BITS) tp); else rgb((BITS) tp);


### PR DESCRIPTION
Refactored code to place the test on verbose before the switch rather than within each switch statements. This is both faster and also resolved a compile note:
"note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'"