### PR TITLE
Use glibtoolize if libtoolize doesn't exist

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,14 +8,17 @@ bail_out()
 	exit 1
 }
 
-echo "Running libtoolize -f -c"
-libtoolize -f -c || bail_out
+LIBTOOLIZE=libtoolize
+command -v $LIBTOOLIZE >/dev/null 2>&1 || LIBTOOLIZE=glibtoolize
+
+echo "Running $LIBTOOLIZE -f -c"
+$LIBTOOLIZE -f -c || bail_out
 
 echo "Running aclocal -I macros"
 aclocal -I macros || bail_out
 
-echo "Running libtoolize --automake"
-libtoolize --automake || bail_out
+echo "Running $LIBTOOLIZE --automake"
+$LIBTOOLIZE --automake || bail_out
 
 echo "Running autoheader -f"
 autoheader -f || bail_out


### PR DESCRIPTION
Running `./autogen.sh` fails on macOS:

```
Running libtoolize -f -c
./autogen.sh: line 12: libtoolize: command not found

  Something went wrong, bailing out!
```

macOS includes Apple libtool, which is not GNU libtool compatible and does not provide a companion libtoolize program.

To avoid confusion with Apple libtool, when GNU libtool is installed separately, it is often installed as glibtool with a companion glibtoolize program. MacPorts does this, for example.

This PR updates autogen.sh to automatically use libtoolize or glibtoolize, whichever exists.